### PR TITLE
release: 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ A Java Client for GreptimeDB, which is compatible with GreptimeDB protocol and l
 - Users can take in-memory snapshots of critical objects, configure them, and write to local files.
   This is helpful when troubleshooting complex issues
 
-## [User Guide](https://docs.greptime.com/user-guide/java-sdk)
+## [User Guide](https://docs.greptime.com/user-guide/java-sdk/java-sdk)

--- a/greptimedb-all/pom.xml
+++ b/greptimedb-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>greptimedb-client</artifactId>
         <groupId>io.greptime</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>greptimedb-all</artifactId>

--- a/greptimedb-common/pom.xml
+++ b/greptimedb-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>greptimedb-client</artifactId>
         <groupId>io.greptime</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>greptimedb-common</artifactId>

--- a/greptimedb-example/pom.xml
+++ b/greptimedb-example/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>greptimedb-client</artifactId>
         <groupId>io.greptime</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>greptimedb-example</artifactId>

--- a/greptimedb-grpc/pom.xml
+++ b/greptimedb-grpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>greptimedb-client</artifactId>
         <groupId>io.greptime</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>greptimedb-grpc</artifactId>

--- a/greptimedb-protocol/pom.xml
+++ b/greptimedb-protocol/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>greptimedb-client</artifactId>
         <groupId>io.greptime</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>greptimedb-protocol</artifactId>
@@ -18,9 +18,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.MichaelScofield</groupId>
+            <groupId>com.github.GreptimeTeam</groupId>
             <artifactId>greptime-proto</artifactId>
-            <version>feat~grpc-client-stream-7d0358eee4-1</version>
+            <version>0a7b790ed4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/greptimedb-protocol/src/main/java/io/greptime/Util.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/Util.java
@@ -155,7 +155,7 @@ public final class Util {
         return err;
     }
 
-    public static <V> Observer<V> toUnaryObserver(CompletableFuture<V> future) {
+    public static <V> Observer<V> toObserver(CompletableFuture<V> future) {
         return new Observer<V>() {
 
             @Override

--- a/greptimedb-protocol/src/main/java/io/greptime/Write.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/Write.java
@@ -47,10 +47,16 @@ public interface Write {
      */
     CompletableFuture<Result<WriteOk, Err>> write(WriteRows rows, Context ctx);
 
+    /**
+     * @see #streamWriter(int, Context)
+     */
     default StreamWriter<WriteRows, WriteOk> streamWriter() {
-        return streamWriter(-1, Context.newDefault());
+        return streamWriter(-1);
     }
 
+    /**
+     * @see #streamWriter(int, Context)
+     */
     default StreamWriter<WriteRows, WriteOk> streamWriter(int maxRowsPerSecond) {
         return streamWriter(maxRowsPerSecond, Context.newDefault());
     }

--- a/greptimedb-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
@@ -166,7 +166,7 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
         // Write flow limit: maximum number of data rows in-flight.
         private int maxInFlightWriteRows = 65536;
         private LimitedPolicy writeLimitedPolicy = LimitedPolicy.defaultWriteLimitedPolicy();
-        private int defaultStreamMaxWriteRowsPerSecond = 200000;
+        private int defaultStreamMaxWriteRowsPerSecond = 65536;
         // In some case of failure, a retry of the read is attempted.
         private int readMaxRetries = 1;
         // Refresh frequency of route tables. The background refreshes all route tables periodically. By default,

--- a/greptimedb-protocol/src/main/java/io/greptime/options/WriteOptions.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/options/WriteOptions.java
@@ -35,7 +35,7 @@ public class WriteOptions implements Copiable<WriteOptions> {
     private int maxInFlightWriteRows = 65536;
     private LimitedPolicy limitedPolicy = LimitedPolicy.defaultWriteLimitedPolicy();
     // Default rate limit for stream writer
-    private int defaultStreamMaxWriteRowsPerSecond = 200000;
+    private int defaultStreamMaxWriteRowsPerSecond = 65536;
 
     public RouterClient getRouterClient() {
         return routerClient;

--- a/greptimedb-protocol/src/main/resources/client_version.properties
+++ b/greptimedb-protocol/src/main/resources/client_version.properties
@@ -1,1 +1,1 @@
-client.version=0.1.1-SNAPSHOT
+client.version=0.1.1

--- a/greptimedb-protocol/src/test/java/io/greptime/UtilTest.java
+++ b/greptimedb-protocol/src/test/java/io/greptime/UtilTest.java
@@ -27,6 +27,6 @@ public class UtilTest {
     @Test
     public void testClientVersion() {
         String ver = Util.clientVersion();
-        Assert.assertEquals("0.1.1-SNAPSHOT", ver);
+        Assert.assertEquals("0.1.1", ver);
     }
 }

--- a/greptimedb-rpc/pom.xml
+++ b/greptimedb-rpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>greptimedb-client</artifactId>
         <groupId>io.greptime</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>greptimedb-rpc</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.greptime</groupId>
     <artifactId>greptimedb-client</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.1</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION

1. 0.1.1-SNAPSHOT -> 0.1.1
2. set `defaultStreamMaxWriteRowsPerSecond` as 65536
3. some data validity checks.