### PR TITLE
feat: add authentication api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ target
 
 *.bak
 .vscode/*
+
+# java language server
+.project
+.classpath
+.settings
+.factorypath

--- a/greptimedb-protocol/src/main/java/io/greptime/GreptimeDB.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/GreptimeDB.java
@@ -232,7 +232,7 @@ public class GreptimeDB implements Write, Query, Lifecycle<GreptimeOptions>, Dis
         writeOpts.setAsyncPool(asyncPool);
         WriteClient writeClient = new WriteClient();
         if (opts.getAuthInfo() != null) {
-            writeClient.setAuthInfo(opts.getAuthInfo());
+            writeOpts.setAuthInfo(opts.getAuthInfo());
         }
         if (!writeClient.init(writeOpts)) {
             throw new IllegalStateException("Fail to start write client");
@@ -246,7 +246,7 @@ public class GreptimeDB implements Write, Query, Lifecycle<GreptimeOptions>, Dis
         queryOpts.setAsyncPool(asyncPool);
         QueryClient queryClient = new QueryClient();
         if (opts.getAuthInfo() != null) {
-            queryClient.setAuthInfo(opts.getAuthInfo());
+            queryOpts.setAuthInfo(opts.getAuthInfo());
         }
         if (!queryClient.init(queryOpts)) {
             throw new IllegalStateException("Fail to start query client");

--- a/greptimedb-protocol/src/main/java/io/greptime/GreptimeDB.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/GreptimeDB.java
@@ -231,6 +231,9 @@ public class GreptimeDB implements Write, Query, Lifecycle<GreptimeOptions>, Dis
         writeOpts.setRouterClient(routerClient);
         writeOpts.setAsyncPool(asyncPool);
         WriteClient writeClient = new WriteClient();
+        if (opts.getAuthInfo() != null) {
+            writeClient.setAuthInfo(opts.getAuthInfo());
+        }
         if (!writeClient.init(writeOpts)) {
             throw new IllegalStateException("Fail to start write client");
         }
@@ -242,6 +245,9 @@ public class GreptimeDB implements Write, Query, Lifecycle<GreptimeOptions>, Dis
         queryOpts.setRouterClient(routerClient);
         queryOpts.setAsyncPool(asyncPool);
         QueryClient queryClient = new QueryClient();
+        if (opts.getAuthInfo() != null) {
+            queryClient.setAuthInfo(opts.getAuthInfo());
+        }
         if (!queryClient.init(queryOpts)) {
             throw new IllegalStateException("Fail to start query client");
         }

--- a/greptimedb-protocol/src/main/java/io/greptime/QueryClient.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/QueryClient.java
@@ -29,7 +29,6 @@ import io.greptime.common.util.SerializingExecutor;
 import io.greptime.flight.AsyncExecCallOption;
 import io.greptime.flight.GreptimeFlightClient;
 import io.greptime.flight.GreptimeRequest;
-import io.greptime.models.AuthInfo;
 import io.greptime.models.Err;
 import io.greptime.models.QueryOk;
 import io.greptime.models.QueryRequest;
@@ -37,7 +36,6 @@ import io.greptime.models.Result;
 import io.greptime.models.SelectRows;
 import io.greptime.options.QueryOptions;
 import io.greptime.rpc.Context;
-import io.greptime.v1.Database;
 import org.apache.arrow.flight.FlightCallHeaders;
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.HeaderCallOption;
@@ -61,15 +59,6 @@ public class QueryClient implements Query, Lifecycle<QueryOptions>, Display {
     private QueryOptions opts;
     private RouterClient routerClient;
     private Executor asyncPool;
-    private AuthInfo authInfo;
-
-    void setAuthInfo(AuthInfo authInfo) {
-        this.authInfo = authInfo;
-    }
-
-    AuthInfo getAuthInfo() {
-        return authInfo;
-    }
 
     @Override
     public boolean init(QueryOptions opts) {
@@ -132,8 +121,8 @@ public class QueryClient implements Query, Lifecycle<QueryOptions>, Display {
             int retries) {
         GreptimeFlightClient flightClient = this.routerClient.getFlightClient(endpoint);
 
-        if (this.authInfo != null) {
-            req.setAuthInfo(this.authInfo);
+        if (this.opts.getAuthInfo() != null) {
+            req.setAuthInfo(this.opts.getAuthInfo());
         }
         GreptimeRequest request = new GreptimeRequest(req.into());
 

--- a/greptimedb-protocol/src/main/java/io/greptime/WriteClient.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/WriteClient.java
@@ -59,15 +59,6 @@ public class WriteClient implements Write, Lifecycle<WriteOptions>, Display {
     private RouterClient routerClient;
     private Executor asyncPool;
     private WriteLimiter writeLimiter;
-    private AuthInfo authInfo;
-
-    void setAuthInfo(AuthInfo authInfo) {
-        this.authInfo = authInfo;
-    }
-
-    AuthInfo getAuthInfo() {
-        return authInfo;
-    }
 
     @Override
     public boolean init(WriteOptions opts) {
@@ -166,8 +157,8 @@ public class WriteClient implements Write, Lifecycle<WriteOptions>, Display {
     private CompletableFuture<Result<WriteOk, Err>> writeTo(Endpoint endpoint, WriteRows rows, Context ctx, int retries) {
         TableName tableName = rows.tableName();
 
-        if (this.getAuthInfo() != null) {
-            rows.setAuthInfo(this.getAuthInfo());
+        if (this.opts.getAuthInfo() != null) {
+            rows.setAuthInfo(this.opts.getAuthInfo());
         }
 
         Database.GreptimeRequest req = rows.into();
@@ -212,8 +203,8 @@ public class WriteClient implements Write, Lifecycle<WriteOptions>, Display {
 
             @Override
             public void onNext(WriteRows rows) {
-                if (WriteClient.this.getAuthInfo() != null) {
-                    rows.setAuthInfo(WriteClient.this.getAuthInfo());
+                if (WriteClient.this.opts.getAuthInfo() != null) {
+                    rows.setAuthInfo(WriteClient.this.opts.getAuthInfo());
                 }
                 rpcObserver.onNext(rows.into());
             }

--- a/greptimedb-protocol/src/main/java/io/greptime/models/AuthInfo.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/models/AuthInfo.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.greptime.models;
+
+import io.greptime.v1.Database;
+
+/**
+ * Greptime authentication information
+ *
+ * @auther sunng87
+ */
+public class AuthInfo {
+
+    private String username;
+    private String password;
+
+    /**
+     * Create AuthInfo from username/password.
+     *
+     */
+    public AuthInfo(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return this.username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Database.AuthHeader intoAuthHeader() {
+        return Database.AuthHeader
+                .newBuilder()
+                .setBasic(
+                        Database.Basic.newBuilder().setUsername(this.getUsername()).setPassword(this.getPassword())
+                                .build()).build();
+    }
+}

--- a/greptimedb-protocol/src/main/java/io/greptime/models/QueryRequest.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/models/QueryRequest.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 public class QueryRequest implements Into<Database.GreptimeRequest> {
     private SelectExprType exprType;
     private String ql;
-    private String databaseName;
+    private Optional<String> databaseName;
     private Optional<AuthInfo> authInfo;
 
     public SelectExprType getExprType() {
@@ -66,8 +66,8 @@ public class QueryRequest implements Into<Database.GreptimeRequest> {
             header_builder.setAuthorization(authHeader);
         }
 
-        if (databaseName != null) {
-            header_builder.setDbname(databaseName);
+        if (databaseName.isPresent()) {
+            header_builder.setDbname(databaseName.get());
         }
 
         switch (getExprType()) {
@@ -138,7 +138,7 @@ public class QueryRequest implements Into<Database.GreptimeRequest> {
             QueryRequest req = new QueryRequest();
             req.exprType = Ensures.ensureNonNull(this.exprType, "null `exprType`");
             req.ql = Ensures.ensureNonNull(this.ql, "null `ql`");
-            req.databaseName = this.databaseName;
+            req.databaseName = Optional.ofNullable(this.databaseName);
             req.authInfo = Optional.empty();
             return req;
         }

--- a/greptimedb-protocol/src/main/java/io/greptime/models/QueryRequest.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/models/QueryRequest.java
@@ -19,6 +19,7 @@ package io.greptime.models;
 import io.greptime.common.Into;
 import io.greptime.common.util.Ensures;
 import io.greptime.v1.Database;
+import java.util.Optional;
 
 /**
  * The query request condition.
@@ -28,6 +29,8 @@ import io.greptime.v1.Database;
 public class QueryRequest implements Into<Database.GreptimeRequest> {
     private SelectExprType exprType;
     private String ql;
+    private String databaseName;
+    private Optional<AuthInfo> authInfo;
 
     public SelectExprType getExprType() {
         return exprType;
@@ -35,6 +38,10 @@ public class QueryRequest implements Into<Database.GreptimeRequest> {
 
     public String getQl() {
         return ql;
+    }
+
+    public void setAuthInfo(AuthInfo authInfo) {
+        this.authInfo = Optional.of(authInfo);
     }
 
     @Override
@@ -52,6 +59,17 @@ public class QueryRequest implements Into<Database.GreptimeRequest> {
     @Override
     public Database.GreptimeRequest into() {
         Database.QueryRequest.Builder builder = Database.QueryRequest.newBuilder();
+
+        Database.RequestHeader.Builder header_builder = Database.RequestHeader.newBuilder();
+        if (authInfo.isPresent()) {
+            Database.AuthHeader authHeader = authInfo.get().intoAuthHeader();
+            header_builder.setAuthorization(authHeader);
+        }
+
+        if (databaseName != null) {
+            header_builder.setDbname(databaseName);
+        }
+
         switch (getExprType()) {
             case Sql:
                 builder.setSql(getQl());
@@ -59,12 +77,16 @@ public class QueryRequest implements Into<Database.GreptimeRequest> {
             case Promql:
                 throw new UnsupportedOperationException("Promql unsupported yet!");
         }
-        return Database.GreptimeRequest.newBuilder().setQuery(builder.build()).build();
+        return Database.GreptimeRequest.newBuilder()
+                    .setHeader(header_builder.build())
+                    .setQuery(builder.build())
+                    .build();
     }
 
     public static class Builder {
         private SelectExprType exprType;
         private String ql;
+        private String databaseName;
 
         /**
          * Sets select expression type, such as sql, promql, etc.
@@ -89,6 +111,17 @@ public class QueryRequest implements Into<Database.GreptimeRequest> {
         }
 
         /**
+         * Set name of the database the query runs on.
+         *
+         * @param databaseName the name
+         * @return builder self
+         */
+        public Builder databaseName(String databaseName) {
+            this.databaseName = databaseName;
+            return this;
+        }
+
+        /**
          * Query language to, using the specified format string and arguments.
          *
          * @param fmtQl format ql string
@@ -107,7 +140,10 @@ public class QueryRequest implements Into<Database.GreptimeRequest> {
             QueryRequest req = new QueryRequest();
             req.exprType = Ensures.ensureNonNull(this.exprType, "null `exprType`");
             req.ql = Ensures.ensureNonNull(this.ql, "null `ql`");
+            req.databaseName = this.databaseName;
+            req.authInfo = Optional.empty();
             return req;
         }
     }
+
 }

--- a/greptimedb-protocol/src/main/java/io/greptime/models/QueryRequest.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/models/QueryRequest.java
@@ -77,10 +77,8 @@ public class QueryRequest implements Into<Database.GreptimeRequest> {
             case Promql:
                 throw new UnsupportedOperationException("Promql unsupported yet!");
         }
-        return Database.GreptimeRequest.newBuilder()
-                    .setHeader(header_builder.build())
-                    .setQuery(builder.build())
-                    .build();
+        return Database.GreptimeRequest.newBuilder().setHeader(header_builder.build()).setQuery(builder.build())
+                .build();
     }
 
     public static class Builder {

--- a/greptimedb-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/options/GreptimeOptions.java
@@ -20,6 +20,7 @@ import io.greptime.common.Copiable;
 import io.greptime.common.Endpoint;
 import io.greptime.common.util.Ensures;
 import io.greptime.limit.LimitedPolicy;
+import io.greptime.models.AuthInfo;
 import io.greptime.rpc.RpcOptions;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,6 +41,7 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
     private RouterOptions routerOptions;
     private WriteOptions writeOptions;
     private QueryOptions queryOptions;
+    private AuthInfo authInfo;
 
     public List<Endpoint> getEndpoints() {
         return endpoints;
@@ -97,12 +99,21 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
         this.queryOptions = queryOptions;
     }
 
+    public AuthInfo getAuthInfo() {
+        return authInfo;
+    }
+
+    public void setAuthInfo(AuthInfo authInfo) {
+        this.authInfo = authInfo;
+    }
+
     @Override
     public GreptimeOptions copy() {
         GreptimeOptions opts = new GreptimeOptions();
         opts.endpoints = new ArrayList<>(this.endpoints);
         opts.asyncWritePool = this.asyncWritePool;
         opts.asyncReadPool = this.asyncReadPool;
+        opts.authInfo = this.authInfo;
         if (this.rpcOptions != null) {
             opts.rpcOptions = this.rpcOptions.copy();
         }
@@ -128,6 +139,7 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
                 ", routerOptions=" + routerOptions + //
                 ", writeOptions=" + writeOptions + //
                 ", queryOptions=" + queryOptions + //
+                ", authInfo=" + authInfo + //
                 '}';
     }
 
@@ -172,6 +184,8 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
         // Refresh frequency of route tables. The background refreshes all route tables periodically. By default,
         // all route tables are refreshed every 30 seconds.
         private long routeTableRefreshPeriodSeconds = 30;
+        // Authentication information
+        private AuthInfo authInfo;
 
         public Builder(List<Endpoint> endpoints) {
             this.endpoints.addAll(endpoints);
@@ -273,6 +287,17 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
         }
 
         /**
+         * Set authentication information.
+         *
+         * @param the authentication information
+         * @return builder self
+         */
+        public Builder authInfo(AuthInfo authInfo) {
+            this.authInfo = authInfo;
+            return this;
+        }
+
+        /**
          * A good start, happy coding.
          *
          * @return nice things
@@ -283,6 +308,7 @@ public class GreptimeOptions implements Copiable<GreptimeOptions> {
             opts.setAsyncWritePool(this.asyncWritePool);
             opts.setAsyncReadPool(this.asyncReadPool);
             opts.setRpcOptions(this.rpcOptions);
+            opts.setAuthInfo(this.authInfo);
 
             RouterOptions routerOpts = new RouterOptions();
             routerOpts.setEndpoints(this.endpoints);

--- a/greptimedb-protocol/src/main/java/io/greptime/options/QueryOptions.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/options/QueryOptions.java
@@ -18,6 +18,7 @@ package io.greptime.options;
 
 import io.greptime.RouterClient;
 import io.greptime.common.Copiable;
+import io.greptime.models.AuthInfo;
 import java.util.concurrent.Executor;
 
 /**
@@ -27,6 +28,7 @@ public class QueryOptions implements Copiable<QueryOptions> {
     private RouterClient routerClient;
     private Executor asyncPool;
     private int maxRetries = 1;
+    private AuthInfo authInfo;
 
     public RouterClient getRouterClient() {
         return routerClient;
@@ -52,12 +54,21 @@ public class QueryOptions implements Copiable<QueryOptions> {
         this.maxRetries = maxRetries;
     }
 
+    public AuthInfo getAuthInfo() {
+        return authInfo;
+    }
+
+    public void setAuthInfo(AuthInfo authInfo) {
+        this.authInfo = authInfo;
+    }
+
     @Override
     public QueryOptions copy() {
         QueryOptions opts = new QueryOptions();
         opts.routerClient = this.routerClient;
         opts.asyncPool = this.asyncPool;
         opts.maxRetries = this.maxRetries;
+        opts.authInfo = this.authInfo;
         return opts;
     }
 
@@ -67,6 +78,7 @@ public class QueryOptions implements Copiable<QueryOptions> {
                 "routerClient=" + routerClient + //
                 ", asyncPool=" + asyncPool + //
                 ", maxRetries=" + maxRetries + //
+                ", authInfo=" + authInfo + //
                 '}';
     }
 }

--- a/greptimedb-protocol/src/main/java/io/greptime/options/WriteOptions.java
+++ b/greptimedb-protocol/src/main/java/io/greptime/options/WriteOptions.java
@@ -19,6 +19,7 @@ package io.greptime.options;
 import io.greptime.RouterClient;
 import io.greptime.common.Copiable;
 import io.greptime.limit.LimitedPolicy;
+import io.greptime.models.AuthInfo;
 import java.util.concurrent.Executor;
 
 /**
@@ -30,6 +31,7 @@ public class WriteOptions implements Copiable<WriteOptions> {
     private RouterClient routerClient;
     private Executor asyncPool;
     private int maxRetries = 1;
+    private AuthInfo authInfo;
 
     // Write flow limit: maximum number of data rows in-flight.
     private int maxInFlightWriteRows = 65536;
@@ -85,6 +87,14 @@ public class WriteOptions implements Copiable<WriteOptions> {
         this.defaultStreamMaxWritePointsPerSecond = defaultStreamMaxWritePointsPerSecond;
     }
 
+    public AuthInfo getAuthInfo() {
+        return this.authInfo;
+    }
+
+    public void setAuthInfo(AuthInfo authInfo) {
+        this.authInfo = authInfo;
+    }
+
     @Override
     public WriteOptions copy() {
         WriteOptions opts = new WriteOptions();
@@ -94,6 +104,7 @@ public class WriteOptions implements Copiable<WriteOptions> {
         opts.maxInFlightWriteRows = this.maxInFlightWriteRows;
         opts.limitedPolicy = this.limitedPolicy;
         opts.defaultStreamMaxWritePointsPerSecond = this.defaultStreamMaxWritePointsPerSecond;
+        opts.authInfo = this.authInfo;
         return opts;
     }
 
@@ -106,6 +117,7 @@ public class WriteOptions implements Copiable<WriteOptions> {
                 ", maxInFlightWriteRows=" + maxInFlightWriteRows + //
                 ", limitedPolicy=" + limitedPolicy + //
                 ", defaultStreamMaxWritePointsPerSecond=" + defaultStreamMaxWritePointsPerSecond + //
+                ", authInfo=" + authInfo + //
                 '}';
     }
 }


### PR DESCRIPTION
Fixes #17 

This patch adds:

- `AuthInfo` class that allows setting username/password on `GreptimeOptions`
- Optional `databaseName` in `QueryRequest` for setting `dbname` in query